### PR TITLE
specified pydantic version 1.9.1

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,6 +4,6 @@ numpy
 packaging
 psutil
 py-cpuinfo
-pydantic
+pydantic==1.9.1
 torch
 tqdm


### PR DESCRIPTION
Pydantic package moved to version 2.0. From https://docs.pydantic.dev/latest/blog/pydantic-v2/:
"While we'll do our best to avoid breaking changes, some things will break.".

When runnning a training in a newly set-up environment with 2.0 version one gets an error:

```
File "[...]/config_utils.py", line 82, in _deprecated_fields_check
      if field.field_info.extra.get("deprecated", False):
  AttributeError: 'FieldInfo' object has no attribute 'field_info'
```

I fixed the pydatinc version to the older, working version. I think it is not worth investigating this further, and adapt the code to pydantic 2, as we plan to move to MegatronLM anyways.